### PR TITLE
Feature: Operator connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ NPM_CMD = npm
 
 build: coverage lint compile
 
-run: lint compile start
+run: test lint compile start
 
 coverage:
 	$(NPM_CMD) run coverage

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "testRegex": "((test|spec))\\.(js|jsx)$"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",
-    "socket.io-client": "^1.7.3"
+    "socket.io-client": "^2.0.3"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",

--- a/src/components/Chat/Chat.jsx
+++ b/src/components/Chat/Chat.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import io from 'socket.io-client';

--- a/src/components/Chat/Chat.test.jsx
+++ b/src/components/Chat/Chat.test.jsx
@@ -18,6 +18,10 @@ const store = {
     chat: {
       messages: [],
       status: 'TEST',
+      session: {
+        id: 'TEST123',
+        client: { id: 'TEST123' },
+      },
     },
   })),
 };

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -14,6 +14,8 @@ export class InputComponent extends Component {
   static propTypes = {
     chatStyle: PropTypes.string,
     chatStatus: PropTypes.string,
+    chatId: PropTypes.string,
+    clientId: PropTypes.string,
     dispatch: PropTypes.func,
     socket: (props, propName) => {
       if (!(propName in props)) {
@@ -33,13 +35,19 @@ export class InputComponent extends Component {
 
   onKeyPress = (event) => {
     const { key, keyCode, shiftKey, ctrlKey, altKey } = event;
+    const { chatId, clientId } = this.props;
     console.log(`INPUT KEYPRESS ${key} (${keyCode}), SHIFT ${shiftKey}, CTRL ${ctrlKey}, ALT ${altKey}`);
 
     if (keyCode === KEY_ENTER) {
       if (!shiftKey) {
         console.log('SENDING MESSAGE ...');
         // Send data
-        this.socket.emit('client:message', event.target.value);
+        this.socket.emit('client:message', JSON.stringify({
+          author: `client.${clientId}`,
+          content: event.target.value,
+          chat: chatId,
+          timestamp: (new Date()).toISOString(),
+        }));
         this.props.dispatch(sendMessage(event.target.value));
         this.setState({ messageBox: '' });
 
@@ -73,6 +81,8 @@ export class InputComponent extends Component {
 const mapStateToProps = state => ({
   chatStyle: state.ui.style,
   chatStatus: state.chat.status,
+  chatId: state.chat.session.id,
+  clientId: state.chat.session.client.id,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import './Input.css';

--- a/src/components/Input/Input.test.jsx
+++ b/src/components/Input/Input.test.jsx
@@ -14,7 +14,13 @@ const store = {
   dispatch: jest.fn(),
   getState: jest.fn(() => ({
     ui: { style: 'TEST' },
-    chat: { status: 'TEST' },
+    chat: {
+      status: 'TEST',
+      session: {
+        id: 'TEST123',
+        client: { id: 'TEST123' },
+      },
+    },
   })),
 };
 

--- a/src/components/Input/__snapshots__/Input.test.jsx.snap
+++ b/src/components/Input/__snapshots__/Input.test.jsx.snap
@@ -1,7 +1,9 @@
 exports[`Input matches snapshot 1`] = `
 <InputComponent
+  chatId="TEST123"
   chatStatus="TEST"
   chatStyle="TEST"
+  clientId="TEST123"
   dispatch={[Function]}
   socket={
     Object {

--- a/src/components/Message/Message.jsx
+++ b/src/components/Message/Message.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import './Message.css';

--- a/src/components/Messages/Messages.jsx
+++ b/src/components/Messages/Messages.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Message from '../Message/Message.jsx';

--- a/src/containers/Chat/actions.js
+++ b/src/containers/Chat/actions.js
@@ -4,6 +4,7 @@ import {
   CHAT_DISCONNECTED,
   // CHAT_RECONNECTED,
   // CHAT_RECONNECTING,
+  CHAT_NEW,
   CHAT_MESSAGE_CLIENT,
   CHAT_MESSAGE_OPERATOR,
 } from './constants';
@@ -18,6 +19,13 @@ export function sendMessage (payload) {
 export function recieveMessage (payload) {
   return {
     type: CHAT_MESSAGE_OPERATOR,
+    payload,
+  };
+}
+
+export function newChat (payload) {
+  return {
+    type: CHAT_NEW,
     payload,
   };
 }

--- a/src/containers/Chat/constants.js
+++ b/src/containers/Chat/constants.js
@@ -3,6 +3,9 @@ export const CHAT_CONNECTED = 'CONNECTED';
 export const CHAT_DISCONNECTED = 'DISCONNECTED';
 export const CHAT_RECONNECTED = 'CONNECTED';
 export const CHAT_RECONNECTING = 'RECONNECTING';
+
+export const CHAT_NEW = 'NEW';
+
 export const CHAT_MESSAGE_CLIENT = 'CHAT_MESSAGE_CLIENT'; // Check
 export const CHAT_MESSAGE_OPERATOR = 'CHAT_MESSAGE_OPERATOR'; // Check
 

--- a/src/containers/Chat/reducer.js
+++ b/src/containers/Chat/reducer.js
@@ -8,6 +8,7 @@ import {
   // CHAT_RECONNECTING,
   CHAT_MESSAGE_CLIENT,
   CHAT_MESSAGE_OPERATOR,
+  CHAT_NEW,
   CHAT_CLIENT,
   CHAT_OPERATOR,
 } from './constants';
@@ -20,8 +21,11 @@ const chatInitialState = {
       { author: 'CLIENT', content: ['Im a client'] },
       { author: 'OPERATOR', content: ['Im an operator'] },
   ],
-    // messages: [],
-
+  session: {
+    client: {
+      id: null,
+    },
+  },
 };
 const chatReducer = function ChatReducer (state = chatInitialState, action) {
   let messages = [];
@@ -36,6 +40,11 @@ const chatReducer = function ChatReducer (state = chatInitialState, action) {
     case CHAT_CONNECTED:
       return Object.assign({}, state, {
         status: action.type,
+      });
+
+    case CHAT_NEW:
+      return Object.assign({}, state, {
+        session: action.payload,
       });
 
     case CHAT_MESSAGE_OPERATOR:


### PR DESCRIPTION
#22 This PR goes along with [minimalchat/daemon#19](https://github.com/minimalchat/daemon/pull/19) and [minimalchat/operator-app#46](https://github.com/minimalchat/operator-app/pull/46)

Small refactor to handle Operator/Client bi-directional communication. Changes:

- Added new `chat:new` event listener to save the Chat session in state
- Refactored emitting events to the sockets to use JSON objects with more context
- Upgraded socket.io from `1.7.3` to `2.0.3`
- Adding `prop-types` and importing PropTypes from that package instead of the deprecated PropTypes in react
- Adding test before run in `Makefile`
