### PR TITLE
Feature/Persist Client

### DIFF
--- a/src/components/App/functions.js
+++ b/src/components/App/functions.js
@@ -1,9 +1,7 @@
 import io from 'socket.io-client';
 
-const remoteHost = process.env.REMOTE_HOST || 'localhost';
-const remotePort = process.env.REMOTE_PORT || '8000';
-
-const socketPath = `http://${remoteHost}:${remotePort}`;
+const remoteHost = process.env.REMOTE_HOST || 'localhost:8000';
+const socketPath = `http://${remoteHost}`;
 
 const sessionStorageKey = 'minimalchat-session';
 
@@ -16,7 +14,6 @@ export function createSocket (app) {
   let storedSessionId = localStorage.getItem(sessionStorageKey);
 
   const socket = io.connect(socketPath, {
-    secure: false,
     reconnectionAttempts: 3,
     query: `type=client&sessionId=${storedSessionId}`,
   });

--- a/src/components/App/functions.js
+++ b/src/components/App/functions.js
@@ -42,7 +42,8 @@ export function createSocket (app) {
   return socket;
 }
 
-export function queryMessages (app) {
+// Fetch past messages from the API
+export function fetchMessages (app) {
   // TODO: Query past messages
   const { session } = app.state;
 

--- a/src/components/App/functions.js
+++ b/src/components/App/functions.js
@@ -20,13 +20,19 @@ export function createSocket (app) {
 
   socket.on('operator:message', app.receiveMessage.bind(app));
   socket.on('operator:typing', app.operatorTyping.bind(app));
-  socket.on('chat:new', e => {
-    const session = JSON.parse(e);
+  socket.on('chat:existing', data => {
+    const session = JSON.parse(data);
 
-    if (storedSessionId == null) {
-      localStorage.setItem(sessionStorageKey, session.id);
-      storedSessionId = session.id;
-    }
+    // TODO: Check if local storage ID different from chat ID
+
+    return app.handleExistingConnection(session);
+  });
+  socket.on('chat:new', data => {
+    const session = JSON.parse(data);
+
+    // Set the session in local storage incase they refresh
+    localStorage.setItem(sessionStorageKey, session.id);
+    storedSessionId = session.id;
 
     return app.handleNewConnection(session);
   });
@@ -34,6 +40,19 @@ export function createSocket (app) {
   socket.on('reconnecting', app.handleReconnecting.bind(app));
 
   return socket;
+}
+
+export function queryMessages (app) {
+  // TODO: Query past messages
+  const { session } = app.state;
+
+  // TODO: Decide whether we should be hitting http or https somehow, somewhere
+  return fetch(`http://${remoteHost}/api/chat/${session.id}/messages`)
+    .then(res => res.json())
+    .then(data => app.loadMessages(data.messages || []))
+    .catch(err => {
+      console.error('Failed to load past messages', err);
+    });
 }
 
 // Message Functions

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -105,18 +105,18 @@ class App extends Component {
     let messages = [];
 
     // Since these are all 'new' we have to run though each and combine accordingly
-    for (let msg of msgs) {
+    for (let i = 0; i < msgs.length; i += 1) {
         messages = combineLastMessage(
           Object.assign({}, {
-            ...msg,
-            content: [msg.content],
+            ...msgs[i],
+            content: [msgs[i].content],
           }),
           messages
         );
     }
 
     this.setState({
-      messages: messages,
+      messages,
     });
   };
 

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -8,6 +8,7 @@ import {
   formatMessageForServer,
   combineLastMessage,
   createSocket,
+  queryMessages,
 } from './functions';
 
 import './styles.css';
@@ -66,6 +67,14 @@ class App extends Component {
     });
   };
 
+  handleExistingConnection = session => {
+    this.setState({
+      session,
+    });
+
+    queryMessages(this);
+  };
+
   handleDisconnected = () => {
     this.setState({
       network: 'disconnected',
@@ -92,7 +101,26 @@ class App extends Component {
 
   // ---  Message Methods
 
-  // save the message to local stage: either combining them or not.
+  loadMessages = msgs => {
+    let messages = [];
+
+    // Since these are all 'new' we have to run though each and combine accordingly
+    for (let msg of msgs) {
+        messages = combineLastMessage(
+          Object.assign({}, {
+            ...msg,
+            content: [msg.content],
+          }),
+          messages
+        );
+    }
+
+    this.setState({
+      messages: messages,
+    });
+  };
+
+  // Save the message to local state
   saveMessageToState = msg => {
     const formattedMsg = formatMessageForClient(
       msg,

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -8,7 +8,7 @@ import {
   formatMessageForServer,
   combineLastMessage,
   createSocket,
-  queryMessages,
+  fetchMessages,
 } from './functions';
 
 import './styles.css';
@@ -72,7 +72,7 @@ class App extends Component {
       session,
     });
 
-    queryMessages(this);
+    fetchMessages(this);
   };
 
   handleDisconnected = () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


## Description
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Save session ID (Chat ID) in Local Storage any time theres a `chat:new` message. If a `chat:existing` comes through, we can pull past messages from the API.

### Motivation
<!-- Why are these changes necessary? -->
To recall previous sessions after navigating away or refreshing the page we need to save the session ID (Chat ID) and send it along, we also want to pull the conversation that was previously happening.

### Changes
<!-- How were these changes implemented? -->
- Added `chat:existing` socket message handler
- Created `queryMessages` function to fetch messages from the API


<!-- 
Feel free to add additional comments

Or Screenshots (bonus points for this!)
-->
