### PR TITLE
Focusing input field when chat is opened

### DIFF
--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -114,11 +114,12 @@ class Chat extends Component {
       handleKeyDown,
       sendMessage,
       theme,
+      chatOpen,
     } = this.props;
 
     return (
       <section className={`Chat--${theme}`}>
-        <Header toggleChat={() => toggleChat(false)} chatOpen={this.props.chatOpen} />
+        <Header toggleChat={() => toggleChat(false)} chatOpen={chatOpen} />
         <Notification network={this.props.network} />
 
         {/* Container for text input and reading messages */}

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,24 +1,38 @@
-import { h } from 'preact';
+import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 
 import { applyTheme } from '../ThemeProvider';
 
 import './styles.css';
 
-const Input = props => {
-  const { sendMessage, theme, textBox, handleInput, handleKeyDown } = props;
-  return (
-    <form className={`Input__form--${theme}`} onSubmit={sendMessage}>
-      <input
-        className={`Input--${theme}`}
-        placeholder="Type Here"
-        onChange={e => handleInput(e)}
-        onKeyDown={e => handleKeyDown(e)}
-        name="messages"
-        value={textBox}
-      />
-    </form>
-  );
+class Input extends Component {
+  componentDidMount () {
+    this.focusInput();
+  }
+
+  focusInput () {
+    if (this.input != null) {
+      this.input.focus();
+    }
+  }
+
+  render () {
+    const { sendMessage, theme, textBox, handleInput, handleKeyDown } = this.props;
+
+    return (
+      <form className={`Input__form--${theme}`} onSubmit={sendMessage}>
+        <input
+          ref={(input) => { this.input = input; }}
+          className={`Input--${theme}`}
+          placeholder="Type Here"
+          onChange={e => handleInput(e)}
+          onKeyDown={e => handleKeyDown(e)}
+          name="messages"
+          value={textBox}
+        />
+      </form>
+    );
+  }
 };
 
 Input.propTypes = {


### PR DESCRIPTION
close #41

<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


## Description
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
When the chat is toggled open the input field is automatically focused and ready for the user to type in.

### Motivation
<!-- Why are these changes necessary? -->

### Changes
<!-- How were these changes implemented? -->
- when the Input component mounts the input element is focused

<!-- 
Feel free to add additional comments

Or Screenshots (bonus points for this!)
-->
