### PR TITLE
fix(css): adds height to chat body, and shadow to chat window.

### DIFF
--- a/src/components/App/styles.css
+++ b/src/components/App/styles.css
@@ -18,6 +18,7 @@
   right: 100px;
   width: 280px;
   height: 360px;
+  box-shadow: rgba(0, 0, 0, 0.12) 0px 0px 2px 0px, rgba(0, 0, 0, 0.24) 0px 2px 4px 0px;
 }
 
 .mnml--messenger.closed {

--- a/src/components/Chat/styles.css
+++ b/src/components/Chat/styles.css
@@ -22,6 +22,7 @@
   overflow-y: scroll;
   margin: 0;
   border-right: 1px solid rgba(0,0,0,0.1);
+  height: 100%;
 }
 
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


## Description
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
adds height to chat body, and shadow to chat window.

### Motivation
<!-- Why are these changes necessary? -->

- I was working on operator-app and using client app, when I sent multiple messages the input box went below window as chat body height was increasing, chat window seemed to be merged in website's page as there is no border on left and website background was white (same as chat window).

### Changes
<!-- How were these changes implemented? -->
- adds height 100% to `.Chat__body--messenger` class for content to be scrolled inside.
-  adds box shadow to `.mnml--messenger` to bring it out from host page.



<!-- 
Feel free to add additional comments

Or Screenshots (bonus points for this!)
-->
I haven't create an issue regarding this, if needed I will create and connect to the issue.

<img width="427" alt="Screenshot 2019-04-27 at 15 53 40" src="https://user-images.githubusercontent.com/3583587/56848292-bfca4280-6904-11e9-933d-1a101cdc91e2.png">
<img width="379" alt="Screenshot 2019-04-27 at 15 54 21" src="https://user-images.githubusercontent.com/3583587/56848295-c3f66000-6904-11e9-81b6-e8db397fe130.png">


